### PR TITLE
Changing the warning to red and the example to red

### DIFF
--- a/config.typ
+++ b/config.typ
@@ -64,13 +64,13 @@
   definition: teal,
   theorem: blue,
   proof: color.eastern,
-  example: black,
+  example: orange,
   proposition: maroon,
   corollary: yellow,
   lemma: aqua,
   remark: lime,
   notation: purple,
-  warning: orange,
+  warning: red,
 )
 
 


### PR DESCRIPTION
To match the flame pictogram in the example and to contrast more the warning i suggest the following color changes.